### PR TITLE
Add support for start/end options for file stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ Asynchronous processing of lines:
 
 If `skipEmptyLines` set to `true`, empty lines don't trigger a 'line' event.
 
+You can also pass `start` and `end` position to read from file region:
+
+```
+{ encoding: 'utf8',
+  skipEmptyLines: true,
+  start: 1000 }
+```
+
 
 **Event: 'line'**
 

--- a/line-by-line.js
+++ b/line-by-line.js
@@ -21,6 +21,15 @@ var LineByLineReader = function (filepath, options) {
 	this._filepath = path.normalize(filepath);
 	this._encoding = options && options.encoding || 'utf8';
 	this._skipEmptyLines = options && options.skipEmptyLines || false;
+	this._streamOptions = { encoding: this._encoding };
+
+	if (options && options.start) {
+		this._streamOptions.start = options.start;
+	}
+
+	if (options && options.end) {
+		this._streamOptions.end = options.end;
+	}
 
 	this._readStream = null;
 	this._lines = [];
@@ -45,7 +54,7 @@ LineByLineReader.prototype = Object.create(events.EventEmitter.prototype, {
 
 LineByLineReader.prototype._initStream = function () {
 	var self = this,
-		readStream = fs.createReadStream(this._filepath, { encoding: this._encoding });
+		readStream = fs.createReadStream(this._filepath, this._streamOptions);
 
 	readStream.on('error', function (err) {
 		self.emit('error', err);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"contributors": ["Markus von der Wehd <mvdw@mwin.de>"],
 	"name": "line-by-line",
 	"description": "A NodeJS module that helps you reading large text files, line by line, without buffering the files into memory.",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"keywords": [ "line", "file", "reader", "fs" ],
 	"homepage": "https://github.com/Osterjour/line-by-line",
 	"repository": {


### PR DESCRIPTION
For big files it's sometimes crucial to be able to set start/end offsets. Because I want to use the library to munch very big amount of data in incremental fashion, I have implemented this patch.
