### PR TITLE
[fix] end event was emitted when the stream read all the file, not wh…

### DIFF
--- a/line-by-line.js
+++ b/line-by-line.js
@@ -91,24 +91,16 @@ LineByLineReader.prototype._nextLine = function () {
 	var self = this,
 		line;
 
-	if (this._end && this._lineFragment) {
-		this.emit('line', this._lineFragment);
-		this._lineFragment = '';
-
-		if (!this._paused) {
-			setImmediate(function () {
-				self.end();
-			});
-		}
-		return;
-	}
-
 	if (this._paused) {
 		return;
 	}
 
 	if (this._lines.length === 0) {
 		if (this._end) {
+			if (this._lineFragment) {
+				this.emit('line', this._lineFragment);
+				this._lineFragment = '';
+			}
 			this.end();
 		} else {
 			this._readStream.resume();
@@ -122,11 +114,11 @@ LineByLineReader.prototype._nextLine = function () {
 		this.emit('line', line);
 	}
 
-	if (!this._paused) {
-		setImmediate(function () {
+	setImmediate(function () {
+		if (!this._paused) {
 			self._nextLine();
-		});
-	}
+		}
+	});
 };
 
 LineByLineReader.prototype.pause = function () {


### PR DESCRIPTION
It seems that the `end` event was sent when the NodeJS `createReadStream` read all the file, not when the line-by-line module has reached the last line of the file. Think it would fix Osterjour/line-by-line#5.
