### PR TITLE
Cleared internal lines buffer so close could be achieved

### DIFF
--- a/line-by-line.js
+++ b/line-by-line.js
@@ -147,6 +147,7 @@ LineByLineReader.prototype.close = function () {
 
 	this._readStream.destroy();
 	this._end = true;
+	this._lines = [];
 
 	setImmediate(function () {
 		self._nextLine();


### PR DESCRIPTION
This commit fixes a bug that prevents the LineByLineReader to immediately stop emitting 'line' events after calling the .close()

In the 'close' method if the _lines array is not cleared, i.e. set to [] then further on in the _nextLine() method you never get to the if(this._end) which if passed causes the actual stop of emitting the 'line' event.
