### PR TITLE
Too early end emit when paused fixed

### DIFF
--- a/line-by-line.js
+++ b/line-by-line.js
@@ -101,7 +101,9 @@ LineByLineReader.prototype._nextLine = function () {
 				this.emit('line', this._lineFragment);
 				this._lineFragment = '';
 			}
-			this.end();
+			if (!this._paused) {
+				this.end();
+			}
 		} else {
 			this._readStream.resume();
 		}


### PR DESCRIPTION
Bug fix for issue:
When reading file line by line "end" event emitted before last "line" async handler completed

```
lineReader.on('line', line => {
	lineReader.pause();
	setTimeout(function () {
		console.log('line');
		lineReader.resume();
	}, 10);
});

lineReader.on('end', () => {
	console.log('end');
});
```

Output before fix (for file with 3 line):
```
line
line
end
line
```