### PR TITLE
emit line event on empty last line if !skipEmptyLines

### DIFF
--- a/line-by-line.js
+++ b/line-by-line.js
@@ -110,7 +110,7 @@ LineByLineReader.prototype._nextLine = function () {
 
 	if (this._lines.length === 0) {
 		if (this._end) {
-			if (this._lineFragment) {
+			if (!this._skipEmptyLines || this._lineFragment) {
 				this.emit('line', this._lineFragment);
 				this._lineFragment = '';
 			}


### PR DESCRIPTION
When skipEmptyLines is false, and the file contains an empty line at the end, a line event was not emitted for the last line.