### PR TITLE
Add support to read from any kind of readable stream

### DIFF
--- a/line-by-line.js
+++ b/line-by-line.js
@@ -21,7 +21,7 @@ var LineByLineReader = function (filepath, options) {
 	var self = this;
 
 	this._encoding = options && options.encoding || 'utf8';
-	if (filepath instanceof stream.Readable) {
+	if (filepath instanceof stream.Readable || filepath.readable === true) {
 		this._readStream = filepath;
 	}
 	else {


### PR DESCRIPTION
I've been working with the [multistream](https://github.com/feross/multistream) lib and I noticed that `line-by-line` did not work because `multistream` combines streams an returns an instance of `MultiStream` while `line-by-line` can only deal with a `stream.Readable` instances or a file path. 

This MR adds support to read from any kind of stream based on stream's `readable` property.